### PR TITLE
Include prom and promhttp directly

### DIFF
--- a/extensions/dbg_peers/dbg_peers.c
+++ b/extensions/dbg_peers/dbg_peers.c
@@ -4,10 +4,10 @@
 
 #include <freeDiameter/extension.h>
 #include <signal.h>
-#include "prom/prom.h"
+#include "prom.h"
 #include <stdio.h>
 #include "microhttpd.h"
-#include "prom/promhttp.h"
+#include "promhttp.h"
 #include <stdbool.h>
 #include <string.h>
 #include "dbg_peers_config.h"


### PR DESCRIPTION
In case of prom and promhttp is already installed in the server, just include them directly.